### PR TITLE
Ruby26

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,4 @@ services:
     container_name: "ap"
     volumes:
       - ./rails:/data
-    command: bash -c "bundle install --path vendor/bundle && bundle exec pumactl start"
+    command: bash -c "bundle install && bundle exec pumactl start"

--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.6
 
 RUN apt-get update && apt-get install -y sqlite3
 


### PR DESCRIPTION
rubyのバグで2.6に上げないとBOM付ファイルが使えないのでやむをえず